### PR TITLE
Refine Compose UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-util:1.5.1")
     implementation("androidx.compose.material:material:1.6.0")
     implementation("androidx.compose.material3:material3:1.2.1")
+    implementation("androidx.compose.material:material-icons-extended:1.6.0")
     implementation("androidx.compose.ui:ui-tooling-preview:1.6.0")
     debugImplementation("androidx.compose.ui:ui-tooling:1.6.0")
 

--- a/app/src/main/java/com/example/weather_notification_service/HomeScreen.kt
+++ b/app/src/main/java/com/example/weather_notification_service/HomeScreen.kt
@@ -4,6 +4,9 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -27,9 +30,22 @@ fun HomeScreen(activity: MainActivity) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceEvenly
     ) {
-        Image(painter = painterResource(android.R.drawable.ic_menu_compass), contentDescription = null, modifier = Modifier.size(80.dp))
-        HomeWeatherInfo(activity)
-        Image(painter = painterResource(android.R.drawable.ic_menu_gallery), contentDescription = null, modifier = Modifier.size(80.dp))
+        Image(
+            painter = painterResource(android.R.drawable.ic_menu_compass),
+            contentDescription = null,
+            modifier = Modifier.size(80.dp)
+        )
+        Card(
+            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+            modifier = Modifier.padding(horizontal = 16.dp)
+        ) {
+            HomeWeatherInfo(activity)
+        }
+        Image(
+            painter = painterResource(android.R.drawable.ic_menu_gallery),
+            contentDescription = null,
+            modifier = Modifier.size(80.dp)
+        )
     }
 }
 
@@ -49,16 +65,16 @@ fun HomeWeatherInfo(activity: MainActivity) {
     val weatherInfoState = viewModel.messageLive.observeAsState()
     val weatherInfo = weatherInfoState.value;
 
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(date, fontSize = 20.sp)
-        Text(time, fontSize = 18.sp)
+    Column(modifier = Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(date, style = MaterialTheme.typography.titleMedium)
+        Text(time, style = MaterialTheme.typography.titleSmall)
         Spacer(modifier = Modifier.height(8.dp))
         Text(weatherInfo?.getString("image")?:"", fontSize = 42.sp)
-        Text(weatherInfo?.getString("weather")?:"", fontSize = 28.sp, fontWeight = FontWeight.Bold)
+        Text(weatherInfo?.getString("weather")?:"", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
         Spacer(modifier = Modifier.height(8.dp))
-        Text(weatherInfo?.getString("message")?:"", fontSize = 16.sp)
+        Text(weatherInfo?.getString("message")?:"", style = MaterialTheme.typography.bodyMedium)
         Spacer(modifier = Modifier.height(16.dp))
-        Text("Alert ON", fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
-        Text("Air Quality Alert: ON", fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+        Text("Alert ON", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.SemiBold)
+        Text("Air Quality Alert: ON", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.SemiBold)
     }
 }

--- a/app/src/main/java/com/example/weather_notification_service/WeatherAlarmApp.kt
+++ b/app/src/main/java/com/example/weather_notification_service/WeatherAlarmApp.kt
@@ -4,6 +4,11 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Air
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -20,16 +25,23 @@ import com.example.weather_notification_service.setting_screen.TemperatureSettin
 fun WeatherAlarmApp(activity: MainActivity) {
     var screen by remember { mutableStateOf(0) }
 
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        TabRow(screen) { screen = it }
-        when (screen) {
-            0 -> HomeScreen(activity)
-            1 -> NotificationSettingsScreen()
-            2 -> TemperatureSettingsScreen()
-            3 -> AirQualitySettingsScreen()
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Weather Alarm") }
+            )
+        },
+        bottomBar = {
+            BottomNavigationBar(currentScreen = screen) { screen = it }
+        }
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            when (screen) {
+                0 -> HomeScreen(activity)
+                1 -> NotificationSettingsScreen()
+                2 -> TemperatureSettingsScreen()
+                3 -> AirQualitySettingsScreen()
+            }
         }
     }
 }
@@ -37,22 +49,21 @@ fun WeatherAlarmApp(activity: MainActivity) {
 
 
 @Composable
-fun TabRow(currentScreen: Int, onTabSelected: (Int) -> Unit) {
-    val tabs = listOf("Home", "Notify", "Temp", "Air")
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 16.dp, bottom = 8.dp),
-        horizontalArrangement = Arrangement.SpaceEvenly
-    ) {
-        tabs.forEachIndexed { index, label ->
-            Button(
+fun BottomNavigationBar(currentScreen: Int, onTabSelected: (Int) -> Unit) {
+    val tabs = listOf(
+        Icons.Default.Home to "Home",
+        Icons.Default.Notifications to "Notify",
+        Icons.Default.Thermostat to "Temp",
+        Icons.Default.Air to "Air"
+    )
+    NavigationBar {
+        tabs.forEachIndexed { index, pair ->
+            NavigationBarItem(
+                selected = currentScreen == index,
                 onClick = { onTabSelected(index) },
-                shape = CircleShape,
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF6A1B9A))
-            ) {
-                Text(label, color = Color.White, fontSize = 14.sp)
-            }
+                icon = { Icon(pair.first, contentDescription = pair.second) },
+                label = { Text(pair.second) }
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Compose icons dependency
- switch main scaffold to use Material top bar and bottom navigation
- polish HomeScreen with Card wrapper and Material typography

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f9d1640c8328a972fd892139859a