### PR TITLE
Add specific time scheduling for alerts

### DIFF
--- a/app/src/main/java/com/example/weather_notification_service/domain/dto/NotificationTimeRequest.kt
+++ b/app/src/main/java/com/example/weather_notification_service/domain/dto/NotificationTimeRequest.kt
@@ -2,6 +2,5 @@ package com.example.weather_notification_service.domain.dto
 
 data class NotificationTimeRequest(
     val memberId: String,
-    val startHour: Int,
-    val endHour: Int,
+    val hours: List<Int>,
 )

--- a/app/src/main/java/com/example/weather_notification_service/setting_screen/CustomSettingScreen.kt
+++ b/app/src/main/java/com/example/weather_notification_service/setting_screen/CustomSettingScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.RangeSlider
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Button
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -39,7 +39,8 @@ fun NotificationSettingsScreen() {
     var dustAlert by remember { mutableStateOf(true) }
     var tempAlert by remember { mutableStateOf(true) }
     var weekendOff by remember { mutableStateOf(false) }
-    var timeRange by remember { mutableStateOf(8f..22f) }
+    var selectedHour by remember { mutableStateOf(8f) }
+    var alertTimes by remember { mutableStateOf(listOf<Int>()) }
 
     LaunchedEffect(Unit) {
         try {
@@ -145,18 +146,31 @@ fun NotificationSettingsScreen() {
         Column(modifier = Modifier.fillMaxWidth()) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(Icons.Default.Schedule, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
-                Text("Receive alerts between")
+                Text("Select alert time")
             }
-            RangeSlider(
-                value = timeRange,
-                onValueChange = { timeRange = it },
-                valueRange = 0f..23f
+            Slider(
+                value = selectedHour,
+                onValueChange = { selectedHour = it },
+                valueRange = 0f..23f,
+                steps = 23
             )
-            Text("${timeRange.start.toInt()}시 - ${timeRange.endInclusive.toInt()}시")
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("${selectedHour.toInt()}시")
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(onClick = {
+                    val hour = selectedHour.toInt()
+                    if (!alertTimes.contains(hour)) {
+                        alertTimes = alertTimes + hour
+                    }
+                }) {
+                    Text("Add Time")
+                }
+            }
+            Text("Selected: ${'$'}{alertTimes.sorted().joinToString(", ") { it.toString() + "시" }}")
             Button(onClick = {
                 coroutineScope.launch {
                     try {
-                        val request = NotificationTimeRequest(memberId, timeRange.start.toInt(), timeRange.endInclusive.toInt())
+                        val request = NotificationTimeRequest(memberId, alertTimes)
                         val response = RetrofitClient.apiService.saveNotificationTime(request)
                         if (response.isSuccessful) {
                             Toast.makeText(context, "시간 설정이 저장되었습니다", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
## Summary
- support sending multiple alert hours to server
- allow user to pick individual alert hours and add them to the list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424b9ef56c83288b43d767eeb3f707