### PR TITLE
Allow minute selection for alert times

### DIFF
--- a/app/src/main/java/com/example/weather_notification_service/domain/dto/NotificationTimeRequest.kt
+++ b/app/src/main/java/com/example/weather_notification_service/domain/dto/NotificationTimeRequest.kt
@@ -2,5 +2,8 @@ package com.example.weather_notification_service.domain.dto
 
 data class NotificationTimeRequest(
     val memberId: String,
-    val hours: List<Int>,
+    /**
+     * List of times in HH:mm format
+     */
+    val times: List<String>,
 )


### PR DESCRIPTION
## Summary
- support minutes when saving alert time configuration
- show separate hour and minute pickers using `NumberPicker`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684864fb75f88328a3f5a22f07d5c458